### PR TITLE
workdir missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ EXPOSE 8000
 
 
 WORKDIR /var/app
+RUN mkdir -p $APP/workdir
 
 # Start the application using either ASGI or Celery depending on APP_MODE
 # XXX: disabling until this is tested more

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ENV WEBPACK_OUTPUT=/var/compiled-static
 
 # Set the working directory
 WORKDIR $APP
-
+RUN mkdir -p $APP/workdir
 
 # Copy requirements.txt to the working directory
 COPY requirements.txt .


### PR DESCRIPTION
### Description
workdir is not created during the initial setup. Updated Dockerfile to create the directory.

### Changes
added the following like to the Dockerfile
 RUN mkdir -p $APP/workdir 

### How Tested
I deleted the directory that had been created manually and then rebuilt everything.

### TODOs
Push to original repository from my fork.
